### PR TITLE
Update LuckPerms API and Minestom dependencies

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,13 +30,13 @@ dependencyResolutionManagement {
             version("togglz", "4.6.1")
             version("aonyx-bom", "0.7.1")
             version("mycelium-bom", "1.6.4")
-            version("luckperms.api", "5.5")
+            version("luckperms.api", "5.6-SNAPSHOT")
 
             // Paper
             library("paper", "io.papermc.paper", "paper-api").versionRef("paper")
             library("aonyx-bom", "net.onelitefeather", "aonyx-bom").versionRef("aonyx-bom")
             library("mycelium-bom", "net.onelitefeather", "mycelium-bom").versionRef("mycelium-bom")
-            library("minestom","net.minestom", "minestom").withoutVersion()
+            library("minestom","net.minestom", "minestom").version("2026.05.17-1.21.11")
             library("adventure.minimessage", "net.kyori", "adventure-text-minimessage").withoutVersion()
             library("togglz", "org.togglz", "togglz-core").versionRef("togglz")
             library("luckperms.api", "net.luckperms", "api").versionRef("luckperms.api")


### PR DESCRIPTION
## Summary
Updated dependency versions in the Gradle version catalog to use newer versions of LuckPerms API and Minestom with explicit version pinning.

## Key Changes
- **LuckPerms API**: Updated from `5.5` to `5.6-SNAPSHOT` to use the latest development version
- **Minestom**: Changed from unversioned dependency to explicitly pinned version `2026.05.17-1.21.11` for Minecraft 1.21.11 compatibility

## Implementation Details
- LuckPerms API now uses a snapshot version, allowing access to pre-release features and fixes
- Minestom dependency now has an explicit version constraint instead of relying on `withoutVersion()`, ensuring consistent builds across environments and improving reproducibility

https://claude.ai/code/session_01S76fk9ma5Szkf9r1W44RVP